### PR TITLE
Database trigger on delete row from found

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZChecker v1.2.0
+# ZChecker v1.2.1
 ZTF moving target checker for short object lists.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ $ zchecker --help
   "log": "/path/to/zchecker.log",
   "user": "IRSA account user name",
   "password": "IRSA account password",
-  "cutout path": "/path/to/cutout/target/directory"
+  "cutout path": "/path/to/cutout/directory",
+  "stack path": "/path/to/stack/directory"
 }
 
 ```

--- a/scripts/zchecker
+++ b/scripts/zchecker
@@ -162,9 +162,10 @@ parser_ztf.set_defaults(func=ztf_update)
 def download_cutouts(args):
     config = Config.from_args(args)
     with ZChecker(config, log=True) as z:
-        z.download_cutouts(clean_failed=args.clean_failed)
+        z.download_cutouts(desg=args.desg, clean_failed=args.clean_failed)
 
 parser_cutout = subparsers.add_parser('download-cutouts', help='download cutouts.', aliases=['cutouts'])
+parser_cutout.add_argument('--desg', help='only download cutouts for this target')
 parser_cutout.add_argument('--path', help='local cutout path')
 parser_cutout.add_argument('--clean-failed', action='store_true', help='Delete file after a failed download.')
 parser_cutout.set_defaults(func=download_cutouts)

--- a/scripts/zchecker
+++ b/scripts/zchecker
@@ -28,7 +28,8 @@ Configuration file format:
   "log": "/path/to/zchecker.log",
   "user": "IRSA account user name",
   "password": "IRSA account password",
-  "cutout path": "/path/to/cutout/target/directory"
+  "cutout path": "/path/to/cutout/directory",
+  "stack path": "/path/to/stack/directory"
 }
 
 ''', formatter_class=argparse.RawTextHelpFormatter)

--- a/scripts/zproject
+++ b/scripts/zproject
@@ -18,15 +18,6 @@ parser.add_argument('--config', default=os.path.expanduser('~/.config/zchecker.c
 parser.add_argument('-v', action='store_true', help='increase verbosity')
 args = parser.parse_args()
 
-def setup_table(z):
-    z.db.execute('''
-    CREATE TABLE IF NOT EXISTS projections(
-    foundid INTEGER PRIMARY KEY,
-    vangleimg INTEGER,
-    sangleimg INTEGER,
-    FOREIGN KEY(foundid) REFERENCES found(foundid)
-    )''')
-
 def update_background(fn):
     import numpy as np
     from numpy import ma
@@ -189,7 +180,6 @@ def project(fn):
 
 with ZChecker(Config.from_args(args), log=True) as z:
     z.logger.info('ZProject')
-    setup_table(z)
 
     path = z.config['cutout path'] + os.path.sep
 
@@ -229,7 +219,7 @@ with ZChecker(Config.from_args(args), log=True) as z:
                     if status[i] is True:
                         z.db.execute('''
                         INSERT OR REPLACE INTO projections
-                        (foundid,vangleimg,sangleimg) VALUES (?,1,1)
+                        (foundid,vangleimg,sangleimg,stacked) VALUES (?,1,1,0)
                         ''', [foundids[i]])
                         z.db.commit()
                         bar.update()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 if __name__ == "__main__":
     setup(name='zchecker',
-          version='1.2.0',
+          version='1.2.1',
           description='ZTF moving target checker for short object lists',
           author="Michael S. P. Kelley",
           author_email="msk@astro.umd.edu",

--- a/zchecker/schema.py
+++ b/zchecker/schema.py
@@ -135,15 +135,17 @@ schema = [
     )''',
 
     # triggers
-    'CREATE TABLE IF NOT EXISTS stale_files(
+    '''CREATE TABLE IF NOT EXISTS stale_files(
       path TEXT,
       archivefile TEXT
-    )',
+    )''',
 
-    '''CREATE TRIGGER IF NOT EXISTS delete_found DELETE ON found
+    '''CREATE TRIGGER IF NOT EXISTS delete_found BEFORE DELETE ON found
     BEGIN
       INSERT INTO stale_files
-        SELECT 'cutout path',archivefile FROM old WHERE archivefile IS NOT NULL;
+        SELECT 'cutout path',archivefile FROM found
+        WHERE foundid=old.foundid
+          AND archivefile IS NOT NULL;
       DELETE FROM projections WHERE foundid=old.foundid;
       INSERT INTO stale_files
         SELECT 'stack path',stackfile FROM stacks

--- a/zchecker/schema.py
+++ b/zchecker/schema.py
@@ -122,7 +122,7 @@ schema = [
     '''CREATE TABLE IF NOT EXISTS projections(
     foundid INTEGER PRIMARY KEY,
     vangleimg INTEGER,
-    sangleimg INTEGER
+    sangleimg INTEGER,
     FOREIGN KEY(foundid) REFERENCES found(foundid)
     )''',
 
@@ -142,17 +142,14 @@ schema = [
 
     '''CREATE TRIGGER IF NOT EXISTS delete_found DELETE ON found
     BEGIN
-      INSERT INTO stale_files (
-        SELECT 'cutout path',archivefile FROM old WHERE archivefile IS NOT NULL
-      );
+      INSERT INTO stale_files
+        SELECT 'cutout path',archivefile FROM old WHERE archivefile IS NOT NULL;
       DELETE FROM projections WHERE foundid=old.foundid;
-      INSERT INTO stale_files (
+      INSERT INTO stale_files
         SELECT 'stack path',stackfile FROM stacks
         WHERE foundid=old.foundid
-          AND stackfile IS NOT NULL
-      );
+          AND stackfile IS NOT NULL;
       DELETE FROM stacks WHERE foundid=old.foundid;
     END;
     ''',
-      
 ]

--- a/zchecker/schema.py
+++ b/zchecker/schema.py
@@ -118,4 +118,41 @@ schema = [
         found.dec)
     FROM found INNER JOIN obs ON obs.pid=found.pid''',
 
+    # for zproject
+    '''CREATE TABLE IF NOT EXISTS projections(
+    foundid INTEGER PRIMARY KEY,
+    vangleimg INTEGER,
+    sangleimg INTEGER
+    FOREIGN KEY(foundid) REFERENCES found(foundid)
+    )''',
+
+    # for zstack
+    '''CREATE TABLE IF NOT EXISTS stacks(
+    foundid INTEGER PRIMARY KEY,
+    stackfile TEXT,
+    stacked INTEGER,
+    FOREIGN KEY(foundid) REFERENCES found(foundid)
+    )''',
+
+    # triggers
+    'CREATE TABLE IF NOT EXISTS stale_files(
+      path TEXT,
+      archivefile TEXT
+    )',
+
+    '''CREATE TRIGGER IF NOT EXISTS delete_found DELETE ON found
+    BEGIN
+      INSERT INTO stale_files (
+        SELECT 'cutout path',archivefile FROM old WHERE archivefile IS NOT NULL
+      );
+      DELETE FROM projections WHERE foundid=old.foundid;
+      INSERT INTO stale_files (
+        SELECT 'stack path',stackfile FROM stacks
+        WHERE foundid=old.foundid
+          AND stackfile IS NOT NULL
+      );
+      DELETE FROM stacks WHERE foundid=old.foundid;
+    END;
+    ''',
+      
 ]


### PR DESCRIPTION
New database trigger, which allows found table row replacements / deletions.  Foreign key constraints prevent 'update or replace' on found when another table refers to that row's foundid.  The trigger also helps prevent stale archive files in the cutouts directory by population a new stale_file table when found rows are deleted.  zchecker inspects this table and removes files when the database is closed.

Because the found table trigger needs to manage the projections table, the projections table definition has been moved from zproject to the zchecker schema file.

Finally, a new configuration option, stack path, has been added for future image stack file management.